### PR TITLE
Drop `Sized` constraint for `to_value`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,6 @@ pub fn from_value<T: serde::de::DeserializeOwned>(value: JsValue) -> Result<T> {
 }
 
 /// Converts a Rust value into a [`JsValue`].
-pub fn to_value<T: serde::ser::Serialize>(value: &T) -> Result<JsValue> {
+pub fn to_value<T: serde::ser::Serialize + ?Sized>(value: &T) -> Result<JsValue> {
     value.serialize(&Serializer::new())
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -176,7 +176,7 @@ fn numbers() {
 #[wasm_bindgen_test]
 fn strings() {
     fn test_str(s: &'static str) {
-        let value = to_value(&s).unwrap();
+        let value = to_value(s).unwrap();
         assert_eq!(value, s);
         let restored: String = from_value(value).unwrap();
         assert_eq!(s, restored);


### PR DESCRIPTION
This allows string literals (and other such values) to be passed to `to_value` without needing an extra `&` in front of them.

Note that `JsValue::from_serde` also has `T: ?Sized` for precisely this reason.