### PR TITLE
Restore Documentation Building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ description = "Native Serde adapter for wasm-bindgen"
 categories = ["development-tools::ffi", "wasm", "encoding"]
 keywords = ["serde", "serialization", "javascript", "wasm", "webassembly"]
 
-[package.metadata.docs.rs]
-features = ["external_doc"]
-
 [dependencies]
 serde = "^1.0"
 js-sys = "^0.3"
@@ -34,5 +31,3 @@ lto = true
 codegen-units = 1
 debug = true
 
-[features]
-external_doc = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,30 @@
-#![cfg_attr(feature = "external_doc", feature(external_doc))]
-#![cfg_attr(feature = "external_doc", doc(include = "../README.md"))]
-#![cfg_attr(feature = "external_doc", warn(missing_docs))]
+//! An alternative to the built-in support within `wasm-bindgen` for converting
+//! Rust types into `JsValue`s. This alternative avoids the intermediate
+//! stringification of Rust values and thus is more efficient.
+//!
+//! # Usage
+//!
+//! To serialize a Rust value into a `JsValue`:
+//!
+//! ```
+//! use wasm_bindgen::JsValue;
+//! use serde::Serialize;
+//! use serde_wasm_bindgen as swb;
+//!
+//! #[derive(Serialize)]
+//! struct Foo {
+//!   num: usize,
+//! }
+//!
+//! pub fn pass_value_to_js() -> Result<JsValue, swb::Error> {
+//!   let foo = Foo { num: 37 };
+//!   swb::to_value(&foo)
+//! }
+//! ```
+//!
+//! Likewise, the [`from_value`] function can be used for deserialization.
+
+#![warn(missing_docs)]
 
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Previously, documentation for this crate was not automatically created by docs.rs, and thus no links to documentation appear on crates.io or lib.rs.

Further, I've added top-level module docs for `lib.rs`, so that users have something to look at. Those module docs contain a doctest of basic usage of the crate to avoid "doc drift" which happened in the README. (See #25)