### PR TITLE
Add json_compatible serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ pub fn get_value_from_js(value: JsValue) -> Result<(), JsValue> {
 
 ## Supported types
 
-Note that, even though it might often be the case, this library doesn't attempt to be strictly compatible with either [`serde_json`](https://docs.serde.rs/serde_json/) or, correspondingly, `JsValue::from_serde` / `JsValue::into_serde`, instead prioritising better compatibility with common JavaScript idioms and representations.
+Note: this library is not strictly compatible with either [`serde_json`](https://docs.serde.rs/serde_json/) or, correspondingly, `JsValue::from_serde` / `JsValue::into_serde`, by default, for better compatibility with common JavaScript idioms and representations. If you need compatibility
+with them, or you want to use `JSON.stringify` on the result without data loss, use `Serializer::json_compatible()` as serializer.
 
 Supported types and values for the deserialization:
  - `()` from `undefined` and `null`.
@@ -62,7 +63,7 @@ Supported types and values for the deserialization:
  - Rust enum from either a string (`"Variant"`) or a plain object. Specific representation is [controlled](https://serde.rs/enum-representations.html) by `#[serde(...)]` attributes and should be compatible with `serde-json`.
 
 Serialization is compatible with the deserialization, but it's limited to a single representation, so it chooses:
- - `undefined` for `()` or `None`.
+ - `undefined` for `()` or `None` (can be configured to use `null` via `serialize_missing_as_null(true)`).
  - ES2015 `Map` for Rust maps (can be configured to use plain objects via `serialize_maps_as_objects(true)`).
  - `Array` for any Rust sequences.
  - `Uint8Array` for byte buffers.

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use serde::ser::Error as SerError;
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::{from_value, to_value, Error, Serializer};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
 use wasm_bindgen::{JsCast, JsValue};
@@ -539,6 +539,23 @@ fn maps_objects_string_key() {
     };
 
     test_via_json_with_config(src, Serializer::new().serialize_maps_as_objects(true));
+}
+
+#[wasm_bindgen_test]
+fn serialize_json_compatible() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct Struct {
+        a: HashMap<String, ()>,
+        b: Option<i32>,
+    }
+    let x = Struct {
+        a: hashmap! {
+            "foo".to_string() => (),
+            "bar".to_string() => (),
+        },
+        b: None,
+    };
+    test_via_json_with_config(x, Serializer::json_compatible());
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
This PR adds `serialize_none_as_null`, `serialize_unit_as_null` plus a `Serializer::json_compatible()` serializer which tries to be compatible with `serde_json` and `JsValue::from_serde`.

I tried to store a `HashMap<String, ()>` (because my library doesn't have HashSet) on localStorage, but I didn't succeed in serializing it because `JSON.stringify` discards `undefined` and ES maps. So in addition to compatibility with `wasm_bindgen`, it helps in working with json.

If there is other incompatibilities with json in serializing that I'm unaware, let's add a configuration for it as well.