### PR TITLE
Optimise some things a bit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ type Result<T> = std::result::Result<T, Error>;
 
 fn static_str_to_js(s: &'static str) -> JsString {
     thread_local! {
-        static CACHE: std::cell::RefCell<fnv::FnvHashMap<&'static str, JsString>> = Default::default();
+        // Since we're mainly optimising for converting the exact same string literal over and over again,
+        // which will always have the same pointer, we can speed things up by indexing by the string's pointer
+        // instead of its value.
+        static CACHE: std::cell::RefCell<fnv::FnvHashMap<*const str, JsString>> = Default::default();
     }
     CACHE.with(|cache| {
         cache

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -66,6 +66,7 @@ impl<S: ser::SerializeStruct<Ok = JsValue, Error = Error>> ser::SerializeStructV
 pub struct ArraySerializer<'s> {
     serializer: &'s Serializer,
     target: Array,
+    idx: u32,
 }
 
 impl<'s> ArraySerializer<'s> {
@@ -73,6 +74,7 @@ impl<'s> ArraySerializer<'s> {
         Self {
             serializer,
             target: Array::new(),
+            idx: 0,
         }
     }
 }
@@ -82,7 +84,8 @@ impl ser::SerializeSeq for ArraySerializer<'_> {
     type Error = Error;
 
     fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
-        self.target.push(&value.serialize(self.serializer)?);
+        self.target.set(self.idx, value.serialize(self.serializer)?);
+        self.idx += 1;
         Ok(())
     }
 


### PR DESCRIPTION
A couple of optimisations:
- Index the string cache by pointer instead of value, since it's quicker to hash and compare, and we're optimising for caching the exact same literal, which will always have the same pointer.
- Use a reference to the strings in the string cache instead of cloning, to avoid some overhead.
- Specialize `deserialize_seq` to index into arrays instead of iterating. (Note: the bigger effect here is probably the fact that indexing is infallible, which avoids the overhead of `try ... catch`.)
- Specialize `deserialize_map` to index into `Object.entries` instead of iterating.
- Serialize arrays by setting indices instead of using `push`. (No idea why this is faster, but it is.)

| Benchmark              | Before        | After         | Change  |
| ---------------------- | ------------- | ------------- | ------- |
| Parse canada           | 46.56 ms/iter | 25.71 ms/iter | -44.78% |
| Parse citm_catalog     | 10.39 ms/iter | 7.12 ms/iter  | -31.47% |
| Parse twitter          | 9.11 ms/iter  | 8.08 ms/iter  | -11.31% |
| Serialize canada       | 11.84 ms/iter | 8.88 ms/iter  | -25.00% |
| Serialize citm_catalog | 7.62 ms/iter  | 6.23 ms/iter  | -18.24% |
| Serialize twitter      | 14.99 ms/iter | 14.28 ms/iter | -4.74%  |