### PR TITLE
Let deserialize_bytes() handle an Array as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ By default, Rust ⬄ JavaScript conversions in `serde-wasm-bindgen` follow this 
 | `HashMap<K, V>`, `BTreeMap`, etc. | `Map<K, V>`                          | any iterable over `[K, V]`     |
 | `Struct { key1: value1, … }`      | `{ key1: value1, … }` object         |                                |
 | tuple, `Vec<T>`, `HashSet`, etc.  | `T[]` array                          | any iterable over `T`          |
-| [`serde_bytes`] byte buffer       | `Uint8Array`                         | `ArrayBuffer`                  |
+| [`serde_bytes`] byte buffer       | `Uint8Array`                         | `ArrayBuffer`, `Array`         |
 
 [as configured in Serde]: https://serde.rs/enum-representations.html
 [safe integer]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
@@ -121,13 +121,14 @@ are additionally supported when deserializing from JavaScript to the Rust type.
 
 ### Serializer configuration options
 
-You can customize serialization from Rust to JavaScript by setting the following options on the [`Serializer::new()`](https://docs.rs/serde-wasm-bindgen/latest/serde_wasm_bindgen/struct.Serializer.html) instance:
+You can customize serialization from Rust to JavaScript by setting the following options on the [`Serializer::new()`](https://docs.rs/serde-wasm-bindgen/latest/serde_wasm_bindgen/struct.Serializer.html) instance (all default to false):
 
 - `.serialize_missing_as_null(true)`: Serialize `()`, unit structs and `Option::None` to `null` instead of `undefined`.
-- `.serialize_maps_as_objects(true)`: Serialize maps into plain JavaScript objects instead of ES2015 Maps. false by default.
+- `.serialize_maps_as_objects(true)`: Serialize maps into plain JavaScript objects instead of ES2015 Maps.
 - `.serialize_large_number_types_as_bigints(true)`: Serialize `u64`, `i64`, `usize` and `isize` to `bigint`s instead of attempting to fit them into the [safe integer] `number` or failing.
+- `.serialize_bytes_as_arrays(true)`: Serialize bytes into plain JavaScript arrays instead of ES2015 Uint8Arrays.
 
-You can also use the `Serializer::json_compatible()` preset to create a JSON compatible serializer. It enables `serialize_missing_as_null` and `serialize_maps_as_objects` under the hood.
+You can also use the `Serializer::json_compatible()` preset to create a JSON compatible serializer. It enables `serialize_missing_as_null`, `serialize_maps_as_objects`, and `serialize_bytes_as_arrays` under the hood.
 
 ## License
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -480,6 +480,20 @@ fn bytes() {
 }
 
 #[wasm_bindgen_test]
+fn bytes_as_array() {
+    let src = [1, 2, 3];
+    // Convert to a JS value
+    let serializer = Serializer::new().serialize_bytes_as_arrays(true);
+    let bytes = &serde_bytes::Bytes::new(&src);
+    let value = bytes.serialize(&serializer).unwrap();
+    // Make sure the JS value is an Array.
+    value.dyn_ref::<js_sys::Array>().unwrap();
+    // Now, try to deserialize back.
+    let deserialized: serde_bytes::ByteBuf = from_value(value).unwrap();
+    assert_eq!(deserialized.as_ref(), src);
+}
+
+#[wasm_bindgen_test]
 fn options() {
     test_via_into(Some(0_u32), 0_u32);
     test_via_into(Some(32_u32), 32_u32);


### PR DESCRIPTION
This solves the problem I was having as well, and I think does what you were suggesting in #43.  In heavily instrumented test code I wrote while investigating this issue, I now see it step through the sequence like it does with other Vec<u8> in the code.

I did not put this in "as_bytes()" as we have no visitor there, and I didn't put it in deserialize_byte_buf() as it didn't seem like the right place as the input isn't one as I understand it.

I am by no means expert in any way with serde, so please provide further guidance if this is not what you meant.