### PR TITLE
Add special handling for dates behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ debug = true
 
 [patch.crates-io]
 proptest = { git = "https://github.com/RReverser/proptest", branch = "fix-wasm" }
+
+[features]
+special-dates = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,9 +1,9 @@
+use crate::SPECIAL_DATE_PREFIX;
 use js_sys::{Array, ArrayBuffer, Date, JsString, Number, Object, Symbol, Uint8Array};
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{self, IntoDeserializer};
 use std::convert::TryFrom;
 use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
-use crate::SPECIAL_DATE_PREFIX;
 
 use super::{static_str_to_js, Error, ObjectExt, Result};
 
@@ -297,10 +297,13 @@ impl<'de> de::Deserializer<'de> for Deserializer {
             if cfg!(feature = "special-dates") {
                 match self.value.dyn_ref::<Date>() {
                     Some(date) => {
-                        let iso_string = date.to_iso_string().as_string().expect_throw("to_iso_string returns a valid string");
+                        let iso_string = date
+                            .to_iso_string()
+                            .as_string()
+                            .expect_throw("to_iso_string returns a valid string");
                         visitor.visit_string(format!("{}{}", SPECIAL_DATE_PREFIX, iso_string))
                     }
-                    None => self.deserialize_map(visitor)
+                    None => self.deserialize_map(visitor),
                 }
             } else {
                 self.deserialize_map(visitor)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub use de::Deserializer;
 pub use error::Error;
 pub use ser::Serializer;
 
+pub(crate) const SPECIAL_DATE_PREFIX: &str = "$::date:";
+
 type Result<T> = std::result::Result<T, Error>;
 
 fn static_str_to_js(s: &'static str) -> JsString {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,6 +2,7 @@ use js_sys::{Array, JsString, Map, Number, Object, Uint8Array};
 use serde::ser::{self, Error as _, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use crate::SPECIAL_DATE_PREFIX;
 
 use super::{static_str_to_js, Error, ObjectExt};
 
@@ -308,9 +309,9 @@ impl<'s> ser::Serializer for &'s Serializer {
 
         serialize_f32(f32);
         serialize_f64(f64);
-
-        serialize_str(&str);
     }
+
+
 
     fn serialize_i64(self, v: i64) -> Result {
         if self.serialize_large_number_types_as_bigints {
@@ -472,5 +473,19 @@ impl<'s> ser::Serializer for &'s Serializer {
             variant,
             self.serialize_struct(variant, len)?,
         ))
+    }
+
+    fn serialize_str(self, v: &str) -> Result {
+        if cfg!(feature = "special-dates") {
+            match v.strip_prefix(SPECIAL_DATE_PREFIX) {
+                Some(v) => {
+                    let date = js_sys::Date::new(&v.into());
+                    Ok(date.into())
+                }
+                None => Ok(v.into())
+            }
+        } else {
+            Ok(v.into())
+        }
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,8 +1,8 @@
+use crate::SPECIAL_DATE_PREFIX;
 use js_sys::{Array, JsString, Map, Number, Object, Uint8Array};
 use serde::ser::{self, Error as _, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use crate::SPECIAL_DATE_PREFIX;
 
 use super::{static_str_to_js, Error, ObjectExt};
 
@@ -311,8 +311,6 @@ impl<'s> ser::Serializer for &'s Serializer {
         serialize_f64(f64);
     }
 
-
-
     fn serialize_i64(self, v: i64) -> Result {
         if self.serialize_large_number_types_as_bigints {
             return Ok(v.into());
@@ -482,7 +480,7 @@ impl<'s> ser::Serializer for &'s Serializer {
                     let date = js_sys::Date::new(&v.into());
                     Ok(date.into())
                 }
-                None => Ok(v.into())
+                None => Ok(v.into()),
             }
         } else {
             Ok(v.into())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -830,11 +830,18 @@ fn dates_are_serialized_as_strings() {
     let mut value: serde_json::Value = from_value(value).unwrap();
 
     let obj = value.as_object_mut().unwrap();
-    obj.insert("anotherValue".to_string(), serde_json::Value::String("something".to_string()));
-    assert!(obj.get("date").unwrap().as_str().unwrap().starts_with("$::date:"));
+    obj.insert(
+        "anotherValue".to_string(),
+        serde_json::Value::String("something".to_string()),
+    );
+    assert!(obj
+        .get("date")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .starts_with("$::date:"));
 
     let to_value = value.serialize(&Serializer::json_compatible()).unwrap();
     let date = js_sys::Reflect::get(&to_value, &"date".into()).unwrap();
     assert!(date.dyn_into::<js_sys::Date>().is_ok())
-
 }


### PR DESCRIPTION
This PR adds special handling for `Date`s. All `Date` objects are deserialized to ISO timestamp strings, prefixed with `$::date:`. When serializing back to JsValue, strings with that prefix are converted to Date objects.

Currently, `Date` are deserialized to `{}`, which is useless. It also silently breaks any expectations that the application may have about the values. This PR introduces a work around for this problem.

This approach is inspired by serde_json, which also uses a [special token](https://github.com/serde-rs/json/blob/0daacdd52e4abb4a47a7f7fc598c5bd4492aa104/src/raw.rs#L292) to encode information about deserialization

Also see #54 