### PR TITLE
Fix using serde_bytes with an internally tagged enum

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -311,6 +311,12 @@ impl<'de> de::Deserializer<'de> for Deserializer {
             visitor.visit_string(v)
         } else if Array::is_array(&self.value) {
             self.deserialize_seq(visitor)
+        } else if self.value.is_instance_of::<Uint8Array>()
+            || self.value.is_instance_of::<ArrayBuffer>()
+        {
+            // We need to handle this here because serde uses `deserialize_any`
+            // for internally tagged enums
+            self.deserialize_byte_buf(visitor)
         } else if self.value.is_object() &&
             // The only reason we want to support objects here is because serde uses
             // `deserialize_any` for internally tagged enums

--- a/src/de.rs
+++ b/src/de.rs
@@ -311,12 +311,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
             visitor.visit_string(v)
         } else if Array::is_array(&self.value) {
             self.deserialize_seq(visitor)
-        } else if self.value.is_instance_of::<Uint8Array>()
-            || self.value.is_instance_of::<ArrayBuffer>()
-        {
+        } else if let Some(bytes) = self.as_bytes() {
             // We need to handle this here because serde uses `deserialize_any`
             // for internally tagged enums
-            self.deserialize_byte_buf(visitor)
+            visitor.visit_byte_buf(bytes)
         } else if self.value.is_object() &&
             // The only reason we want to support objects here is because serde uses
             // `deserialize_any` for internally tagged enums

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -608,7 +608,8 @@ fn enums() {
         Map(BTreeMap<A, B>),
         Bytes {
             #[serde(with = "serde_bytes")]
-            bytes: Vec<u8>,
+            serde_bytes: Vec<u8>,
+            raw: Vec<u8>,
         },
     }
 
@@ -647,7 +648,8 @@ fn enums() {
 
     test_via_round_trip_with_config(
         InternallyTagged::<(), ()>::Bytes {
-            bytes: vec![0, 1, 2],
+            serde_bytes: vec![0, 1, 2],
+            raw: vec![3, 4, 5],
         },
         &SERIALIZER,
     );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -598,9 +598,18 @@ fn enums() {
         A: Ord,
     {
         Unit,
-        Struct { a: A, b: B },
-        Sequence { seq: Vec<A> },
+        Struct {
+            a: A,
+            b: B,
+        },
+        Sequence {
+            seq: Vec<A>,
+        },
         Map(BTreeMap<A, B>),
+        Bytes {
+            #[serde(with = "serde_bytes")]
+            bytes: Vec<u8>,
+        },
     }
 
     test_via_json(InternallyTagged::Unit::<(), ()>);
@@ -634,6 +643,13 @@ fn enums() {
             b: -10_i64,
         },
         &BIGINT_SERIALIZER,
+    );
+
+    test_via_round_trip_with_config(
+        InternallyTagged::<(), ()>::Bytes {
+            bytes: vec![0, 1, 2],
+        },
+        &SERIALIZER,
     );
 
     test_enum! {


### PR DESCRIPTION
Before this change, if you wanted to use an internally tagged enum with serde_wasm_bindgen and serde_bytes you would receive the error "invalid type: byte array, expected any value". After this change it will correctly deserialize the object to a Vec<u8>.