### PR TITLE
docs: Update crate minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ enabled, to allow your types to be serialized and deserialized with Serde.
 ```toml
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.4"
+serde-wasm-bindgen = "0.6"
 ```
 
 ### Derive the `Serialize` and `Deserialize` Traits


### PR DESCRIPTION
Just a chore version update, but this threw me off and resulted in surprising errors when trying out this crate, because 0.4 does not contain important features like `serde_wasm_bindgen::preserve`