### PR TITLE
Preserve Jsvalue with a slab instead of unstable abi methods

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,16 @@ jobs:
         uses: jetli/wasm-pack-action@v0.4.0
       - name: Run tests in Node.js
         run: wasm-pack test --node
+        env:
+          RUSTFLAGS: '--cfg=getrandom_backend="wasm_js" -D warnings'
       - name: Run tests in Chrome
         run: wasm-pack test --headless --chrome
+        env:
+          RUSTFLAGS: '--cfg=getrandom_backend="wasm_js" -D warnings'
       - name: Run tests in Firefox
         run: wasm-pack test --headless --firefox
+        env:
+          RUSTFLAGS: '--cfg=getrandom_backend="wasm_js" -D warnings'
       - name: Clippy checks
         run: cargo clippy --all-targets -- -D warnings
       - name: Format

--- a/src/de.rs
+++ b/src/de.rs
@@ -484,10 +484,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     /// but if we get a hint that they're expected, this methods allows to avoid heap allocations
     /// of an intermediate `String` by directly converting numeric codepoints instead.
     fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        if let Some(s) = self.value.dyn_ref::<JsString>()
-            && let Some(c) = s.as_char()
-        {
-            return visitor.visit_char(c);
+        if let Some(s) = self.value.dyn_ref::<JsString>() {
+            if let Some(c) = s.as_char() {
+                return visitor.visit_char(c);
+            }
         }
         self.invalid_type(visitor)
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -2,11 +2,10 @@ use js_sys::{Array, ArrayBuffer, JsString, Map, Number, Object, Symbol, Uint8Arr
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{self, IntoDeserializer};
 use std::convert::TryFrom;
-use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 
 use crate::preserve::PRESERVED_VALUE_MAGIC;
-use crate::{static_str_to_js, Error, ObjectExt, Result};
+use crate::{Error, ObjectExt, Result, static_str_to_js};
 
 /// Provides [`de::SeqAccess`] from any JS iterator.
 struct SeqAccess {
@@ -130,9 +129,11 @@ impl<'de> de::SeqAccess<'de> for PreservedValueAccess {
                 seed.deserialize(str_deserializer(PRESERVED_VALUE_MAGIC))
                     .map(Some)
             }
+            // Stash the value and smuggle its stash slot to
+            // `preserve::deserialize`, which pops it right back out.
             Self::OnValue(value) => seed
                 .deserialize(Deserializer {
-                    value: JsValue::from(value.into_abi()),
+                    value: JsValue::from(crate::preserve::stash(value)),
                 })
                 .map(Some),
             Self::Done => Ok(None),
@@ -294,8 +295,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
                 Ok(v) => visitor.visit_i64(v),
                 Err(value) => match u64::try_from(value) {
                     Ok(v) => visitor.visit_u64(v),
-                    Err(_) => Err(de::Error::custom("Couldn't deserialize i64 or u64 from a BigInt outside i64::MIN..u64::MAX bounds"))
-                }
+                    Err(_) => Err(de::Error::custom(
+                        "Couldn't deserialize i64 or u64 from a BigInt outside i64::MIN..u64::MAX bounds",
+                    )),
+                },
             }
         } else if let Some(v) = self.value.as_f64() {
             if Number::is_safe_integer(&self.value) {
@@ -481,10 +484,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     /// but if we get a hint that they're expected, this methods allows to avoid heap allocations
     /// of an intermediate `String` by directly converting numeric codepoints instead.
     fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        if let Some(s) = self.value.dyn_ref::<JsString>() {
-            if let Some(c) = s.as_char() {
-                return visitor.visit_char(c);
-            }
+        if let Some(s) = self.value.dyn_ref::<JsString>()
+            && let Some(c) = s.as_char()
+        {
+            return visitor.visit_char(c);
         }
         self.invalid_type(visitor)
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 
 use crate::preserve::PRESERVED_VALUE_MAGIC;
-use crate::{static_str_to_js, Error, ObjectExt, Result};
+use crate::{Error, ObjectExt, Result, static_str_to_js};
 
 /// Provides [`de::SeqAccess`] from any JS iterator.
 struct SeqAccess {
@@ -295,8 +295,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
                 Ok(v) => visitor.visit_i64(v),
                 Err(value) => match u64::try_from(value) {
                     Ok(v) => visitor.visit_u64(v),
-                    Err(_) => Err(de::Error::custom("Couldn't deserialize i64 or u64 from a BigInt outside i64::MIN..u64::MAX bounds"))
-                }
+                    Err(_) => Err(de::Error::custom(
+                        "Couldn't deserialize i64 or u64 from a BigInt outside i64::MIN..u64::MAX bounds",
+                    )),
+                },
             }
         } else if let Some(v) = self.value.as_f64() {
             if Number::is_safe_integer(&self.value) {
@@ -482,10 +484,10 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     /// but if we get a hint that they're expected, this methods allows to avoid heap allocations
     /// of an intermediate `String` by directly converting numeric codepoints instead.
     fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        if let Some(s) = self.value.dyn_ref::<JsString>() {
-            if let Some(c) = s.as_char() {
-                return visitor.visit_char(c);
-            }
+        if let Some(s) = self.value.dyn_ref::<JsString>()
+            && let Some(c) = s.as_char()
+        {
+            return visitor.visit_char(c);
         }
         self.invalid_type(visitor)
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 
 use crate::preserve::PRESERVED_VALUE_MAGIC;
-use crate::{Error, ObjectExt, Result, static_str_to_js};
+use crate::{static_str_to_js, Error, ObjectExt, Result};
 
 /// Provides [`de::SeqAccess`] from any JS iterator.
 struct SeqAccess {
@@ -295,10 +295,8 @@ impl<'de> de::Deserializer<'de> for Deserializer {
                 Ok(v) => visitor.visit_i64(v),
                 Err(value) => match u64::try_from(value) {
                     Ok(v) => visitor.visit_u64(v),
-                    Err(_) => Err(de::Error::custom(
-                        "Couldn't deserialize i64 or u64 from a BigInt outside i64::MIN..u64::MAX bounds",
-                    )),
-                },
+                    Err(_) => Err(de::Error::custom("Couldn't deserialize i64 or u64 from a BigInt outside i64::MIN..u64::MAX bounds"))
+                }
             }
         } else if let Some(v) = self.value.as_f64() {
             if Number::is_safe_integer(&self.value) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,14 +102,112 @@ pub fn to_value<T: serde::ser::Serialize + ?Sized>(value: &T) -> Result<JsValue>
 /// will return a JsValue representing an object with two fields (`int_field` and `js_field`), where
 /// `js_field` will be an `Int8Array` pointing to the same underlying JavaScript object as `s.js_field` does.
 pub mod preserve {
-    use serde::{de::Error, Deserialize, Serialize};
-    use wasm_bindgen::{
-        convert::{FromWasmAbi, IntoWasmAbi},
-        JsCast, JsValue,
-    };
+    use serde::{Deserialize, Serialize, de::Error};
+    use std::cell::RefCell;
+    use wasm_bindgen::{JsCast, JsValue};
 
     // Some arbitrary string that no one will collide with unless they try.
     pub(crate) const PRESERVED_VALUE_MAGIC: &str = "1fc430ca-5b7f-4295-92de-33cf2b145d38";
+
+    enum Slot {
+        Occupied(JsValue),
+        Free { next: Option<usize> },
+    }
+
+    /// A slab of values being passed between the `preserve` entry points
+    /// and our `Serializer`/`Deserializer` out-of-band: serde's data
+    /// model cannot carry a `JsValue`, so one side stashes the value here
+    /// and smuggles its slot through serde as a number, and the other
+    /// side takes it back out.
+    ///
+    /// In a plain round-trip the take happens immediately after the
+    /// stash, but serde adaptors that buffer and replay events may
+    /// reorder or interleave the two halves, so slots are taken by id
+    /// rather than in stack order. A foreign serializer/deserializer that
+    /// takes the MAGIC branch's place never takes its slot: the take of a
+    /// never-stashed slot fails cleanly instead of producing a wrong
+    /// value, and freed slots are reused by later preserve operations.
+    struct Stash {
+        slots: Vec<Slot>,
+        free: Option<usize>,
+    }
+
+    impl Stash {
+        const fn new() -> Self {
+            Self {
+                slots: Vec::new(),
+                free: None,
+            }
+        }
+
+        /// Stash a value for the matching [`Stash::take`] and return its
+        /// slot.
+        fn stash(&mut self, value: JsValue) -> usize {
+            if let Some(slot) = self.free {
+                let entry = &mut self.slots[slot];
+                let Slot::Free { next } = entry else {
+                    unreachable!("free list pointed at an occupied slab slot");
+                };
+                self.free = *next;
+                *entry = Slot::Occupied(value);
+                slot
+            } else {
+                let slot = self.slots.len();
+                self.slots.push(Slot::Occupied(value));
+                slot
+            }
+        }
+
+        /// Take back a [`stash`](Stash::stash)ed value; `None` if `slot`
+        /// was never stashed or was already taken (a protocol violation,
+        /// e.g. a value that went through a foreign serializer).
+        fn take(&mut self, slot: usize) -> Option<JsValue> {
+            let value = self.free_slot(slot)?;
+            Some(value)
+        }
+
+        /// Release a slot without returning the stashed value.
+        fn discard(&mut self, slot: usize) {
+            self.free_slot(slot);
+        }
+
+        fn free_slot(&mut self, slot: usize) -> Option<JsValue> {
+            let entry = self.slots.get_mut(slot)?;
+            if matches!(entry, Slot::Free { .. }) {
+                return None;
+            }
+            let old_entry = std::mem::replace(entry, Slot::Free { next: self.free });
+            let Slot::Occupied(value) = old_entry else {
+                unreachable!("checked for free slab slot before replacing it");
+            };
+
+            self.free = Some(slot);
+            Some(value)
+        }
+    }
+
+    std::thread_local! {
+        static STASH: RefCell<Stash> = const { RefCell::new(Stash::new()) };
+    }
+
+    // Slots cross the serde boundary as `u32` because `u32` is the widest
+    // integer that our `Serializer`/`Deserializer` handle as a plain JS
+    // number regardless of configuration (`usize` goes through
+    // `serialize_u64`, which becomes a `BigInt` under
+    // `serialize_large_number_types_as_bigints`).
+
+    pub(crate) fn stash(value: JsValue) -> u32 {
+        let slot = STASH.with(|stash| stash.borrow_mut().stash(value));
+        u32::try_from(slot).expect("more than u32::MAX preserved values stashed at once")
+    }
+
+    pub(crate) fn take_stashed(slot: u32) -> Option<JsValue> {
+        STASH.with(|stash| stash.borrow_mut().take(slot as usize))
+    }
+
+    pub(crate) fn discard_stashed(slot: u32) {
+        STASH.with(|stash| stash.borrow_mut().discard(slot as usize));
+    }
 
     struct Magic;
 
@@ -153,10 +251,12 @@ pub mod preserve {
     ///
     /// This function is compatible with the `serde(serialize_with)` derive annotation.
     pub fn serialize<S: serde::Serializer, T: JsCast>(val: &T, ser: S) -> Result<S::Ok, S::Error> {
-        // It's responsibility of serde-wasm-bindgen's Serializer to clone the value.
-        // For all other serializers, using reference instead of cloning here will ensure that we don't
-        // create accidental leaks.
-        PreservedValueSerWrapper(val.as_ref().into_abi()).serialize(ser)
+        // The matching MAGIC branch in our `Serializer` pops this clone
+        // right back out of the stash.
+        let slot = stash(val.as_ref().clone());
+        let result = PreservedValueSerWrapper(slot).serialize(ser);
+        discard_stashed(slot);
+        result
     }
 
     /// Deserialize any `JsCast` value.
@@ -167,21 +267,59 @@ pub mod preserve {
     /// This function is compatible with the `serde(deserialize_with)` derive annotation.
     pub fn deserialize<'de, D: serde::Deserializer<'de>, T: JsCast>(de: D) -> Result<T, D::Error> {
         let wrap = PreservedValueDeWrapper::deserialize(de)?;
-        // When used with our deserializer this unsafe is correct, because the
-        // deserializer just converted a JsValue into_abi.
-        //
-        // Other deserializers are unlikely to end up here, thanks
-        // to the asymmetry between PreservedValueSerWrapper and
-        // PreservedValueDeWrapper. Even if some other deserializer ends up
-        // here, this may be incorrect but it shouldn't be UB because JsValues
-        // are represented using indices into a JS-side (i.e. bounds-checked)
-        // array.
-        let val: JsValue = unsafe { FromWasmAbi::from_abi(wrap.1) };
+        // When used with our deserializer, the deserializer just stashed
+        // this value. Other deserializers won't have stashed anything (and
+        // are unlikely to end up here at all, thanks to the asymmetry
+        // between PreservedValueSerWrapper and PreservedValueDeWrapper),
+        // which the slot check turns into a clean error.
+        let val: JsValue = take_stashed(wrap.1).ok_or_else(|| {
+            D::Error::custom("preserved value was not stashed by serde-wasm-bindgen")
+        })?;
         val.dyn_into().map_err(|e| {
             D::Error::custom(format_args!(
                 "incompatible JS value {e:?} for type {}",
                 std::any::type_name::<T>()
             ))
         })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn stash_reuses_freed_slots() {
+            let mut stash = Stash::new();
+
+            let first = stash.stash(JsValue::UNDEFINED);
+            let second = stash.stash(JsValue::UNDEFINED);
+            assert_eq!(first, 0);
+            assert_eq!(second, 1);
+
+            assert!(stash.take(first).is_some());
+            let reused = stash.stash(JsValue::UNDEFINED);
+            assert_eq!(reused, first);
+
+            assert!(stash.take(second).is_some());
+            assert!(stash.take(reused).is_some());
+
+            let after_clear = stash.stash(JsValue::UNDEFINED);
+            assert_eq!(after_clear, reused);
+            assert!(stash.take(after_clear).is_some());
+        }
+
+        #[test]
+        fn discard_is_idempotent() {
+            let mut stash = Stash::new();
+
+            let slot = stash.stash(JsValue::UNDEFINED);
+            assert!(stash.take(slot).is_some());
+            stash.discard(slot);
+
+            let reused = stash.stash(JsValue::UNDEFINED);
+            assert_eq!(reused, 0);
+            stash.discard(reused);
+            assert!(stash.take(reused).is_none());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,16 +162,6 @@ pub mod preserve {
         /// was never stashed or was already taken (a protocol violation,
         /// e.g. a value that went through a foreign serializer).
         fn take(&mut self, slot: usize) -> Option<JsValue> {
-            let value = self.free_slot(slot)?;
-            Some(value)
-        }
-
-        /// Release a slot without returning the stashed value.
-        fn discard(&mut self, slot: usize) {
-            self.free_slot(slot);
-        }
-
-        fn free_slot(&mut self, slot: usize) -> Option<JsValue> {
             let entry = self.slots.get_mut(slot)?;
             if matches!(entry, Slot::Free { .. }) {
                 return None;
@@ -195,7 +185,6 @@ pub mod preserve {
     // number regardless of configuration (`usize` goes through
     // `serialize_u64`, which becomes a `BigInt` under
     // `serialize_large_number_types_as_bigints`).
-
     pub(crate) fn stash(value: JsValue) -> u32 {
         let slot = STASH.with(|stash| stash.borrow_mut().stash(value));
         u32::try_from(slot).expect("more than u32::MAX preserved values stashed at once")
@@ -203,10 +192,6 @@ pub mod preserve {
 
     pub(crate) fn take_stashed(slot: u32) -> Option<JsValue> {
         STASH.with(|stash| stash.borrow_mut().take(slot as usize))
-    }
-
-    pub(crate) fn discard_stashed(slot: u32) {
-        STASH.with(|stash| stash.borrow_mut().discard(slot as usize));
     }
 
     struct Magic;
@@ -255,7 +240,7 @@ pub mod preserve {
         // right back out of the stash.
         let slot = stash(val.as_ref().clone());
         let result = PreservedValueSerWrapper(slot).serialize(ser);
-        discard_stashed(slot);
+        take_stashed(slot);
         result
     }
 
@@ -314,11 +299,11 @@ pub mod preserve {
 
             let slot = stash.stash(JsValue::UNDEFINED);
             assert!(stash.take(slot).is_some());
-            stash.discard(slot);
+            stash.take(slot);
 
             let reused = stash.stash(JsValue::UNDEFINED);
             assert_eq!(reused, 0);
-            stash.discard(reused);
+            stash.take(reused);
             assert!(stash.take(reused).is_none());
         }
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,11 +1,10 @@
 use js_sys::{Array, JsString, Map, Number, Object, Uint8Array};
 use serde::ser::{self, Error as _, Serialize};
-use wasm_bindgen::convert::RefFromWasmAbi;
-use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
 
 use crate::preserve::PRESERVED_VALUE_MAGIC;
-use crate::{static_str_to_js, Error, ObjectExt};
+use crate::{Error, ObjectExt, static_str_to_js};
 
 type Result<T = JsValue> = super::Result<T>;
 
@@ -442,11 +441,18 @@ impl<'s> ser::Serializer for &'s Serializer {
         value: &T,
     ) -> Result {
         if name == PRESERVED_VALUE_MAGIC {
-            let abi = value.serialize(self)?.unchecked_into_f64() as u32;
-            // `PreservedValueSerWrapper` gives us ABI of a reference to a `JsValue` that is
-            // guaranteed to be alive only during this call.
-            // We must clone it before giving away the value to the caller.
-            return Ok(unsafe { JsValue::ref_from_abi(abi) }.as_ref().clone());
+            // `PreservedValueSerWrapper` stashed the value and smuggled its
+            // stash slot to us as a `u32` (which we serialize as a plain JS
+            // number under any configuration); pop the value right back out.
+            let slot = value.serialize(self)?;
+            let slot = slot
+                .as_f64()
+                .filter(|&f| f as u32 as f64 == f)
+                .map(|f| f as u32)
+                .ok_or_else(|| Error::custom("preserved value slot is not a valid integer"))?;
+            return crate::preserve::take_stashed(slot).ok_or_else(|| {
+                Error::custom("preserved value was not stashed by serde-wasm-bindgen")
+            });
         }
         value.serialize(self)
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -444,12 +444,7 @@ impl<'s> ser::Serializer for &'s Serializer {
             // `PreservedValueSerWrapper` stashed the value and smuggled its
             // stash slot to us as a `u32` (which we serialize as a plain JS
             // number under any configuration); pop the value right back out.
-            let slot = value.serialize(self)?;
-            let slot = slot
-                .as_f64()
-                .filter(|&f| f as u32 as f64 == f)
-                .map(|f| f as u32)
-                .ok_or_else(|| Error::custom("preserved value slot is not a valid integer"))?;
+            let slot = value.serialize(self)?.unchecked_into_f64() as u32;
             return crate::preserve::take_stashed(slot).ok_or_else(|| {
                 Error::custom("preserved value was not stashed by serde-wasm-bindgen")
             });

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Error as SerError;
 use serde::{Deserialize, Serialize};
-use serde_wasm_bindgen::{from_value, to_value, Error, Serializer};
+use serde_wasm_bindgen::{Error, Serializer, from_value, to_value};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -96,9 +96,9 @@ fn sample_js_values() -> Vec<(ValueKind, JsValue)> {
         (ValueKind::Boolean, JsValue::TRUE),
         (ValueKind::PosFloat, JsValue::from(0.5)),
         (ValueKind::NegFloat, JsValue::from(-0.5)),
-        (ValueKind::NaN, JsValue::from(std::f64::NAN)),
-        (ValueKind::PosInfinity, JsValue::from(std::f64::INFINITY)),
-        (ValueKind::NegInfinity, JsValue::from(-std::f64::INFINITY)),
+        (ValueKind::NaN, JsValue::from(f64::NAN)),
+        (ValueKind::PosInfinity, JsValue::from(f64::INFINITY)),
+        (ValueKind::NegInfinity, JsValue::from(-f64::INFINITY)),
         (ValueKind::PosInt, JsValue::from(1)),
         (ValueKind::NegInt, JsValue::from(-1)),
         (ValueKind::PosBigInt, JsValue::from(BigInt::from(1_i64))),
@@ -467,6 +467,7 @@ fn bytes() {
     let value = to_value(&serde_bytes::Bytes::new(&src)).unwrap();
     // Modify the original storage to make sure that JS value is a copy.
     src[0] = 10;
+    assert_eq!(src, [10, 2, 3]);
 
     // Make sure the JS value is a Uint8Array
     let res = value.dyn_ref::<js_sys::Uint8Array>().unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Error as SerError;
 use serde::{Deserialize, Serialize};
-use serde_wasm_bindgen::{from_value, to_value, Error, Serializer};
+use serde_wasm_bindgen::{Error, Serializer, from_value, to_value};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -96,9 +96,9 @@ fn sample_js_values() -> Vec<(ValueKind, JsValue)> {
         (ValueKind::Boolean, JsValue::TRUE),
         (ValueKind::PosFloat, JsValue::from(0.5)),
         (ValueKind::NegFloat, JsValue::from(-0.5)),
-        (ValueKind::NaN, JsValue::from(std::f64::NAN)),
-        (ValueKind::PosInfinity, JsValue::from(std::f64::INFINITY)),
-        (ValueKind::NegInfinity, JsValue::from(-std::f64::INFINITY)),
+        (ValueKind::NaN, JsValue::from(f64::NAN)),
+        (ValueKind::PosInfinity, JsValue::from(f64::INFINITY)),
+        (ValueKind::NegInfinity, JsValue::from(-f64::INFINITY)),
         (ValueKind::PosInt, JsValue::from(1)),
         (ValueKind::NegInt, JsValue::from(-1)),
         (ValueKind::PosBigInt, JsValue::from(BigInt::from(1_i64))),
@@ -467,6 +467,7 @@ fn bytes() {
     let value = to_value(&serde_bytes::Bytes::new(&src)).unwrap();
     // Modify the original storage to make sure that JS value is a copy.
     src[0] = 10;
+    assert_ne!(src, orig_src);
 
     // Make sure the JS value is a Uint8Array
     let res = value.dyn_ref::<js_sys::Uint8Array>().unwrap();
@@ -910,4 +911,106 @@ fn field_aliases() {
     }
 
     test_via_round_trip_with_config(Struct { a: 42, c: 84 }, &SERIALIZER);
+}
+
+/// The `preserve` smuggling protocol assumes its two halves run back to
+/// back. serde machinery that buffers and replays values (`flatten` on
+/// deserialization, untagged enums) breaks that pairing; these tests pin
+/// the resulting behavior: serialization through `flatten` works (no
+/// buffering on the serialize side), while the buffered deserialization
+/// paths fail with a clean error rather than producing a wrong value.
+#[wasm_bindgen_test]
+fn preserved_value_protocol_edges() {
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Inner {
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        a: JsValue,
+        n: u32,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct InnerB {
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        b: JsValue,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Outer {
+        #[serde(flatten)]
+        i1: Inner,
+        #[serde(flatten)]
+        i2: InnerB,
+        #[serde(with = "serde_wasm_bindgen::preserve")]
+        c: JsValue,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(untagged)]
+    enum Un {
+        WithPreserve {
+            #[serde(with = "serde_wasm_bindgen::preserve")]
+            x: JsValue,
+            tag: u32,
+        },
+        Other {
+            y: String,
+        },
+    }
+
+    let marker_a: JsValue = js_sys::Symbol::for_("A").into();
+    let marker_b: JsValue = js_sys::Symbol::for_("B").into();
+    let marker_c: JsValue = js_sys::Symbol::for_("C").into();
+
+    // Serializing through `flatten` forwards directly (no buffering), so
+    // preserved values pass through by identity — even several of them.
+    // `flatten` makes serde treat the struct as a map, which serializes
+    // to an ES `Map` under the default config.
+    let out = to_value(&Outer {
+        i1: Inner {
+            a: marker_a.clone(),
+            n: 7,
+        },
+        i2: InnerB {
+            b: marker_b.clone(),
+        },
+        c: marker_c.clone(),
+    })
+    .unwrap();
+    let map = out.dyn_into::<js_sys::Map>().unwrap();
+    assert_eq!(map.get(&"a".into()), marker_a);
+    assert_eq!(map.get(&"n".into()), JsValue::from_f64(7.0));
+    assert_eq!(map.get(&"b".into()), marker_b);
+    assert_eq!(map.get(&"c".into()), marker_c);
+
+    // Deserializing through `flatten` buffers values into serde's
+    // internal `Content`, which never reaches the smuggling protocol:
+    // clean error, not a wrong value.
+    from_value::<Outer>(map.into()).unwrap_err();
+
+    // Same for a preserved field inside an untagged enum variant...
+    let obj = Object::new();
+    js_sys::Reflect::set(&obj, &"x".into(), &marker_a).unwrap();
+    js_sys::Reflect::set(&obj, &"tag".into(), &1.into()).unwrap();
+    from_value::<Un>(obj.into()).unwrap_err();
+
+    // ...while other variants of the same enum still deserialize.
+    let obj = Object::new();
+    js_sys::Reflect::set(&obj, &"y".into(), &"hello".into()).unwrap();
+    match from_value::<Un>(obj.into()).unwrap() {
+        Un::Other { y } => assert_eq!(y, "hello"),
+        other => panic!("expected Un::Other, got {other:?}"),
+    }
+
+    // A foreign serializer can serialize the magic wrapper (the smuggled
+    // number ends up in its output, meaningless outside this crate), and
+    // native round-trips keep working afterwards.
+    serde_json::to_string(&InnerB {
+        b: marker_b.clone(),
+    })
+    .unwrap();
+    let out = to_value(&InnerB {
+        b: marker_c.clone(),
+    })
+    .unwrap();
+    assert_eq!(js_sys::Reflect::get(&out, &"b".into()).unwrap(), marker_c);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Error as SerError;
 use serde::{Deserialize, Serialize};
-use serde_wasm_bindgen::{Error, Serializer, from_value, to_value};
+use serde_wasm_bindgen::{from_value, to_value, Error, Serializer};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -96,9 +96,9 @@ fn sample_js_values() -> Vec<(ValueKind, JsValue)> {
         (ValueKind::Boolean, JsValue::TRUE),
         (ValueKind::PosFloat, JsValue::from(0.5)),
         (ValueKind::NegFloat, JsValue::from(-0.5)),
-        (ValueKind::NaN, JsValue::from(f64::NAN)),
-        (ValueKind::PosInfinity, JsValue::from(f64::INFINITY)),
-        (ValueKind::NegInfinity, JsValue::from(-f64::INFINITY)),
+        (ValueKind::NaN, JsValue::from(std::f64::NAN)),
+        (ValueKind::PosInfinity, JsValue::from(std::f64::INFINITY)),
+        (ValueKind::NegInfinity, JsValue::from(-std::f64::INFINITY)),
         (ValueKind::PosInt, JsValue::from(1)),
         (ValueKind::NegInt, JsValue::from(-1)),
         (ValueKind::PosBigInt, JsValue::from(BigInt::from(1_i64))),
@@ -467,7 +467,6 @@ fn bytes() {
     let value = to_value(&serde_bytes::Bytes::new(&src)).unwrap();
     // Modify the original storage to make sure that JS value is a copy.
     src[0] = 10;
-    assert_ne!(src, orig_src);
 
     // Make sure the JS value is a Uint8Array
     let res = value.dyn_ref::<js_sys::Uint8Array>().unwrap();
@@ -911,106 +910,4 @@ fn field_aliases() {
     }
 
     test_via_round_trip_with_config(Struct { a: 42, c: 84 }, &SERIALIZER);
-}
-
-/// The `preserve` smuggling protocol assumes its two halves run back to
-/// back. serde machinery that buffers and replays values (`flatten` on
-/// deserialization, untagged enums) breaks that pairing; these tests pin
-/// the resulting behavior: serialization through `flatten` works (no
-/// buffering on the serialize side), while the buffered deserialization
-/// paths fail with a clean error rather than producing a wrong value.
-#[wasm_bindgen_test]
-fn preserved_value_protocol_edges() {
-    #[derive(Serialize, Deserialize, Debug)]
-    struct Inner {
-        #[serde(with = "serde_wasm_bindgen::preserve")]
-        a: JsValue,
-        n: u32,
-    }
-
-    #[derive(Serialize, Deserialize, Debug)]
-    struct InnerB {
-        #[serde(with = "serde_wasm_bindgen::preserve")]
-        b: JsValue,
-    }
-
-    #[derive(Serialize, Deserialize, Debug)]
-    struct Outer {
-        #[serde(flatten)]
-        i1: Inner,
-        #[serde(flatten)]
-        i2: InnerB,
-        #[serde(with = "serde_wasm_bindgen::preserve")]
-        c: JsValue,
-    }
-
-    #[derive(Serialize, Deserialize, Debug)]
-    #[serde(untagged)]
-    enum Un {
-        WithPreserve {
-            #[serde(with = "serde_wasm_bindgen::preserve")]
-            x: JsValue,
-            tag: u32,
-        },
-        Other {
-            y: String,
-        },
-    }
-
-    let marker_a: JsValue = js_sys::Symbol::for_("A").into();
-    let marker_b: JsValue = js_sys::Symbol::for_("B").into();
-    let marker_c: JsValue = js_sys::Symbol::for_("C").into();
-
-    // Serializing through `flatten` forwards directly (no buffering), so
-    // preserved values pass through by identity — even several of them.
-    // `flatten` makes serde treat the struct as a map, which serializes
-    // to an ES `Map` under the default config.
-    let out = to_value(&Outer {
-        i1: Inner {
-            a: marker_a.clone(),
-            n: 7,
-        },
-        i2: InnerB {
-            b: marker_b.clone(),
-        },
-        c: marker_c.clone(),
-    })
-    .unwrap();
-    let map = out.dyn_into::<js_sys::Map>().unwrap();
-    assert_eq!(map.get(&"a".into()), marker_a);
-    assert_eq!(map.get(&"n".into()), JsValue::from_f64(7.0));
-    assert_eq!(map.get(&"b".into()), marker_b);
-    assert_eq!(map.get(&"c".into()), marker_c);
-
-    // Deserializing through `flatten` buffers values into serde's
-    // internal `Content`, which never reaches the smuggling protocol:
-    // clean error, not a wrong value.
-    from_value::<Outer>(map.into()).unwrap_err();
-
-    // Same for a preserved field inside an untagged enum variant...
-    let obj = Object::new();
-    js_sys::Reflect::set(&obj, &"x".into(), &marker_a).unwrap();
-    js_sys::Reflect::set(&obj, &"tag".into(), &1.into()).unwrap();
-    from_value::<Un>(obj.into()).unwrap_err();
-
-    // ...while other variants of the same enum still deserialize.
-    let obj = Object::new();
-    js_sys::Reflect::set(&obj, &"y".into(), &"hello".into()).unwrap();
-    match from_value::<Un>(obj.into()).unwrap() {
-        Un::Other { y } => assert_eq!(y, "hello"),
-        other => panic!("expected Un::Other, got {other:?}"),
-    }
-
-    // A foreign serializer can serialize the magic wrapper (the smuggled
-    // number ends up in its output, meaningless outside this crate), and
-    // native round-trips keep working afterwards.
-    serde_json::to_string(&InnerB {
-        b: marker_b.clone(),
-    })
-    .unwrap();
-    let out = to_value(&InnerB {
-        b: marker_c.clone(),
-    })
-    .unwrap();
-    assert_eq!(js_sys::Reflect::get(&out, &"b".into()).unwrap(), marker_c);
 }


### PR DESCRIPTION
Currently serde-wasm-bindgen relies on the unstable wasm bindgen `convert` module to store raw indexes into the js object map which can break in any minor release.

This PR reworks the implementation to instead store a index into a slab of stashed jsvalues on the rust side instead of relying on that unstable abi. This makes serialization ~15% slower for preserved JsValues. My assumption is that this path is not performance critical since it serializes the same id string alongside every jsvalue.